### PR TITLE
allow .tiff extension, allow arbitrary filenames for non-multifile tiffs

### DIFF
--- a/gcamp_extractor/multifiletiff.py
+++ b/gcamp_extractor/multifiletiff.py
@@ -65,7 +65,7 @@ class MultiFileTiff():
                 self.root = self.root + '/'
 
             ## Find all tiff files in root folder
-            self.filenames = glob.glob(self.root + '*.tif')
+            self.filenames = glob.glob(self.root + '*.tif') + glob.glob(self.root + '*.tiff')
 
             ## If they don't exist, find all tiff files in subdirectory
             if len(self.filenames) == 0:
@@ -76,7 +76,8 @@ class MultiFileTiff():
         if len(self.filenames) == 0:
             print('Not the root to a directory')
             return 0 
-        self.sort_filenames()
+        if len(self.filenames) > 1:
+            self.sort_filenames()
         
         ## Create TiffFile objects for each file in directory
         self.tf = []
@@ -204,7 +205,7 @@ class MultiFileTiff():
             if os.path.isdir(fullPath):
                 allFiles = allFiles + self.list_files_tiff(fullPath)
             else:
-            	if fullPath[-4:]=='.tif':
+            	if fullPath[-4:]=='.tif' or fullPath[-5:]=='.tiff':
                 	allFiles.append(fullPath)
 
         return allFiles
@@ -443,8 +444,12 @@ class MultiFileTiff():
 
         if self.filenames[0][-8:] == '.ome.tif':    
             files = [self.filenames[i][:-8] for i in range(len(self.filenames))]
+        elif self.filenames[0][-9:] == '.ome.tiff':    
+            files = [self.filenames[i][:-9] for i in range(len(self.filenames))]
         elif self.filenames[0][-4:] == '.tif':
             files = [self.filenames[i][:-4] for i in range(len(self.filenames))]
+        elif self.filenames[0][-5:] == '.tiff':
+            files = [self.filenames[i][:-5] for i in range(len(self.filenames))]
 
         ndx = []
         for i in range(len(files)):


### PR DESCRIPTION
### purpose ###
Allow use of `.tiff` file extension (in addition to `.tif`). When only one tiff is detected in source directory, do not enforce multifile filename convention.

Note that when more than one tiff is present in source directory, all tiffs must use same file extension, and multifile filename convention must be followed (i.e. files should end in `_01.tif`, `_02.tif`, etc such that the ending digits of the filenames correspond to intended sorted order of individual files).

### testing ###
Invoke `python example.py` on directories containing single `.tif` file, single `.tiff` file, two `.tif` files, and two `.tiff` files. Verify that script completes successfully in all cases.