### PR TITLE
Napari curator rebase

### DIFF
--- a/gcamp_extractor/Curator.py
+++ b/gcamp_extractor/Curator.py
@@ -1,20 +1,16 @@
-from .Extractor import *
-from .Threads import *
-import numpy as np
-import matplotlib.pyplot as plt
-from matplotlib.widgets import Button, Slider, CheckButtons, TextBox, RadioButtons
-from .multifiletiff import *
-import json
 import atexit
+import json
+import napari
+import numpy as np
 
-from magicgui import magicgui
-from magicgui._qt.widgets import QDoubleSlider
+from .Extractor import *
+from .multifiletiff import *
+from .Threads import *
+from matplotlib.backends.backend_qt5agg import FigureCanvas
+from matplotlib.figure import Figure
 from qtpy.QtWidgets import QAbstractItemView, QAction, QSlider, QButtonGroup, QLabel, QListWidget, QListWidgetItem, QMenu, QPushButton, QRadioButton
 from qtpy.QtCore import Qt, QPoint, QSize
 from qtpy.QtGui import QPixmap, QCursor, QImage, QIcon
-import napari
-from matplotlib.backends.backend_qt5agg import FigureCanvas
-from matplotlib.figure import Figure
 
 def subaxis(im, position, window = 100):
     """


### PR DESCRIPTION
### Purpose ###
Port curator from matplotlib to napari. Add navigable timeseries grid widget.

### Testing ###
Output from napari curator matches output from matplotlib curator:
With each branch, perform extraction with `example.py`. Then, perform curation on first seven traces with action sequence `keep`, `keep`, `pass`, `keep`, `keep`, `keep`, `trash`. Verify that resulting `curate.json` files are identical.

Widget testing:
Click all buttons and verify that views change as expected. For timeseries grid, verify that double clicking on a trace loads that trace, and verify that selecting multiple traces with `ctrl+click` and then right clicking and selecting `Keep selected` or `Trash selected` changes view as expected.