### PR TITLE
moved reg_peaks to segfunctions

### DIFF
--- a/gcamp_extractor/Threads.py
+++ b/gcamp_extractor/Threads.py
@@ -5,41 +5,6 @@ import scipy.spatial
 from scipy.optimize import linear_sum_assignment
 import copy
 
-def reg_peaks(im, peaks, thresh = 36, anisotropy = (6,1,1)):
-    """
-    function that drops peaks that are found too close to each other (Not used by Spool or Thread)
-    """
-    peaks = np.array(peaks)
-    anisotropy = np.array(anisotropy,dtype=int)
-    for i in range(len(anisotropy)):
-        peaks[:,i]*=anisotropy[i]
-
-    diff = scipy.spatial.distance.cdist(peaks,peaks,metric='euclidean')
-    complete = False
-    while not complete:
-        try:
-            x,y = np.where(diff == np.min(diff[diff!=0]))
-            if diff[x,y] >= thresh:
-                complete = True
-            else:
-                peak1 = peaks[x]
-                peak2 = peaks[y]
-
-                if im[peak1] > im[peak2]:
-                    diff = np.delete(diff, y, axis = 0)
-                    diff = np.delete(diff, y, axis = 1)
-                    peaks = np.delete(peaks, y, axis = 0)
-                else:
-                    diff = np.delete(diff, x, axis = 0)
-                    diff = np.delete(diff, x, axis = 1)
-                    peaks = np.delete(peaks, x, axis = 0)
-        except:
-            complete = True
-
-    for i in range(len(anisotropy)):
-        peaks[:,i]= peaks[:,i]/anisotropy[i]
-    return peaks.astype(int)
-
 class Spool:
     """
     New class for spool, for 'flocking' behavior

--- a/gcamp_extractor/segfunctions.py
+++ b/gcamp_extractor/segfunctions.py
@@ -3,6 +3,43 @@
 import numpy as np
 import cv2
 import scipy.ndimage
+import scipy.spatial
+
+def reg_peaks(im, peaks, thresh = 36, anisotropy = (6,1,1)):
+    """
+    function that drops peaks that are found too close to each other (Not used by Spool or Thread)
+    """
+    peaks = np.array(peaks)
+    anisotropy = np.array(anisotropy,dtype=int)
+    for i in range(len(anisotropy)):
+        peaks[:,i]*=anisotropy[i]
+
+    diff = scipy.spatial.distance.cdist(peaks,peaks,metric='euclidean')
+    complete = False
+    while not complete:
+        try:
+            x,y = np.where(diff == np.min(diff[diff!=0]))
+            if diff[x,y] >= thresh:
+                complete = True
+            else:
+                peak1 = peaks[x]
+                peak2 = peaks[y]
+
+                if im[peak1] > im[peak2]:
+                    diff = np.delete(diff, y, axis = 0)
+                    diff = np.delete(diff, y, axis = 1)
+                    peaks = np.delete(peaks, y, axis = 0)
+                else:
+                    diff = np.delete(diff, x, axis = 0)
+                    diff = np.delete(diff, x, axis = 1)
+                    peaks = np.delete(peaks, x, axis = 0)
+        except:
+            complete = True
+
+    for i in range(len(anisotropy)):
+        peaks[:,i]= peaks[:,i]/anisotropy[i]
+    return peaks.astype(int)
+
 
 def convAxis(im, axis, kernel):
     '''


### PR DESCRIPTION
### purpose
By moving ```reg_peaks()``` into segfunctions.py, all of the segmentation tools are consolidated into one place. This would allow us to move segfunctions.py to a more general home (GCE being specific to gcamp recordings) and nuke all of the copy-paste duplicates of the same functions elsewhere.

### testing
example.py still works