### PR TITLE
update for new improc functions

### DIFF
--- a/gcamp_extractor/Extractor.py
+++ b/gcamp_extractor/Extractor.py
@@ -409,7 +409,7 @@ class BlobThreadTracker():
                         peaks = np.rint(self.algorithm_params["template_peaks"]).astype(int)
                     except:
                         peaks = peak_local_max(expanded_im, min_distance=9, num_peaks=50)
-                        peaks //= self.anisotropy
+                        peaks //= self.im.anisotropy
                     chunks = get_bounded_chunks(data=im1, peaks=peaks, pad=[1, 25, 25])
                     self.templates = [np.mean(chunks, axis=0)]
                     quantiles = self.algorithm_params.get('quantiles', [0.5])


### PR DESCRIPTION
### Purpose ###
This is the second piece of an effort spanning four repos to centralize template matching code. These repos are:
1. https://github.com/focolab/wb-utils: current source of authority
2. https://github.com/focolab/image-processing: future (centralized) source of authority
3. https://github.com/focolab/gcamp-extractor: client which currently duplicates code from `wb-utils` and depends on `image-processing`; should import currently duplicated code from `image-processing` instead
4. https://github.com/focolab/bfd-core: hosts an example which currently imports template matching code from `wb-utils` to do peakfinding; should import from `image-processing` instead

Work items to complete this migration are as follows:
1. Refactor currently duplicated code and move it into `image-processing` ([DONE](https://github.com/focolab/image-processing/pull/1))
2. Update `wb-utils` to remove currently duplicated code and call refactored version in `image-processing` instead
3. Update `gcamp-extractor` to remove currently duplicated code and call refactored version in `image-processing` instead (this change)
4. Update `wb-utils` to remove currently duplicated code and call refactored version in `image-processing` instead

### Testing ###
1. Uninstall `image-processing` locally with `pip uninstall improc`, then reinstall dependencies with `pip install -e .`
2. Verify that `example.py` still runs without errors