### PR TITLE
fix setup.py to allow improc install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setuptools.setup(
           'tifffile>=0.15.1',
           'opencv-python-headless>=4.1.0.25',
           'matplotlib>=2.1.0',
-          'improc @ git+https://github.com/focolab/image-processing',
+          'improc @ git+ssh://git@github.com/focolab/image-processing',
           'imreg_dft',
           'fastcluster',
           'napari[all]',


### PR DESCRIPTION
I'm unable to install `gcamp-extractor` into a new conda environment due to a git authentication error (required for `image-processing`). The modified setup.py in this pull request does work, but uses ssh for git authentication which may not be what we ultimately want.


```bash
(gce01) gbubnis@thedude:~/prj/bfd/testt/gcetest/gcamp-extractor$ pip install -e .
Obtaining file:///home/gbubnis/prj/bfd/testt/gcetest/gcamp-extractor
Collecting improc@ git+https://github.com/focolab/image-processing
  Cloning https://github.com/focolab/image-processing to /tmp/pip-install-de09_af_/improc_11bf30e080914fa8bd1a61abfd4ce70c
  Running command git clone -q https://github.com/focolab/image-processing /tmp/pip-install-de09_af_/improc_11bf30e080914fa8bd1a61abfd4ce70c
Username for 'https://github.com': gregbubnis
Password for 'https://gregbubnis@github.com': 
  remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead.
  remote: Please see https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/ for more information.
  fatal: Authentication failed for 'https://github.com/focolab/image-processing/'
WARNING: Discarding git+https://github.com/focolab/image-processing. Command errored out with exit status 128: git clone -q https://github.com/focolab/image-processing /tmp/pip-install-de09_af_/improc_11bf30e080914fa8bd1a61abfd4ce70c Check the logs for full command output.                                                                             
Collecting numpy>=1.13.3
  Using cached numpy-1.21.2-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl (15.8 MB)
Collecting scipy>=1.0.0
  Using cached scipy-1.7.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl (28.4 MB)
Collecting tifffile>=0.15.1
  Using cached tifffile-2021.8.30-py3-none-any.whl (171 kB)
Collecting opencv-python-headless>=4.1.0.25
  Using cached opencv_python_headless-4.5.3.56-cp38-cp38-manylinux2014_x86_64.whl (37.1 MB)
Collecting matplotlib>=2.1.0
  Using cached matplotlib-3.4.3-cp38-cp38-manylinux1_x86_64.whl (10.3 MB)
ERROR: Could not find a version that satisfies the requirement improc (unavailable) (from gcamp-extractor) (from versions: none)
ERROR: No matching distribution found for improc (unavailable)

```