### PR TITLE
Bug fixes

### DIFF
--- a/eats_worm/Extractor.py
+++ b/eats_worm/Extractor.py
@@ -723,7 +723,7 @@ class BlobThreadTracker():
                         shift = tuple(np.rint(_off).astype(int))
                         axis = tuple(np.arange(im1.ndim))
                         last_im = np.copy(im1)
-                        if np.max(shift) > 0:
+                        if np.max(np.abs(shift)) > 0:
                             im1 = np.roll(im1, shift, axis)
                             if shift[0] >= 0:
                                 im1[:shift[0], :, :] = 0
@@ -733,7 +733,7 @@ class BlobThreadTracker():
                                 im1[:, :shift[1], :] = 0
                             else:
                                 im1[:, shift[1]:, :] = 0
-                            if shift[2] >- 0:
+                            if shift[2] >= 0:
                                 im1[:, :, :shift[2]] = 0
                             else:
                                 im1[:, :, shift[2]:] = 0

--- a/eats_worm/Threads.py
+++ b/eats_worm/Threads.py
@@ -100,7 +100,7 @@ class Spool:
                 interpolated = (self.threads[match[0]].get_position_mostrecent()-positions[match[1]]) / delta_t
                 for t in range(delta_t):
                     self.dvec[self.t - 1 + t] -= interpolated
-                    self.threads[match[0]].update_position(positions[match[1]] + interpolated * (delta_t - t), t=self.t+t, found = True)
+                    self.threads[match[0]].update_position(positions[match[1]] + interpolated * (delta_t - t - 1), t=self.t+t, found = True)
             if matchings.any():
                 for t in range(delta_t):
                     self.dvec[self.t - 1 + t] *= 1/len(matchings)


### PR DESCRIPTION
### Purpose
To resolve critical bugs in the motion correction and neuron tracking logic that caused volumetric data loss, skipped image registrations, and position interpolation errors.

### Changes
**Motion Correction (`calc_blob_threads`)**
* **Corrected Z-Axis Data Deletion:** Fixed a typo in the Z-axis padding conditional (changed `>- 0` to `>= 0`). This ensures frames with a shift of exactly 0 evaluate correctly as an empty slice (`im1[:, :, :0] = 0`), preventing the entire Z-axis from being inadvertently overwritten with zeros.
* **Fixed Skipped Registrations:** Updated the execution conditional from `np.max(shift) > 0` to `np.max(np.abs(shift)) > 0`. This guarantees that the realignment logic is applied to all non-zero translation vectors, resolving the issue where frames with strictly negative shifts were skipped entirely.

**Thread Tracking (`Spool.reel`)**
* **Fixed Interpolation Off-By-One Error:** Corrected the linear interpolation formula used to populate intervening frames between previous (`prev`) and current (`curr`) neuron detections.
* Updated the formula from `positions[match[1]] + interpolated * (delta_t - t)` to `positions[match[1]] + interpolated * (delta_t - 1 - t)`.
* This ensures the current detection is accurately anchored at the final iteration (`t = delta_t - 1`). This resolves the critical failure in frame-by-frame (`delta_t = 1`) algorithms where threads never advanced, as well as the compounding positional drift seen across windows in TMIP algorithms (`delta_t > 1`).

### Testing
* **Visual Validation:** Confirmed that frame-by-frame (`delta_t = 1`) detection methods now successfully track neurons.
* Comparison tests were omitted because the prior implementation's logic and output were fundamentally incorrect.

### Implications
* Previous analyses using the tool may suffer from subpar detection or tracking of neurons between frames but these changes do not affect the actual quantification or loading in previous quantifications. 